### PR TITLE
fix mistyping buf instead of buff

### DIFF
--- a/core/debug.c
+++ b/core/debug.c
@@ -54,7 +54,7 @@ int DisplayDebug(const int message_debug_level, const int user_debug_level, cons
     if (buff_size < 0)
     {
         DisplayError("DisplayDebug vsnprintf failed");
-        if (buf)
+        if (buff)
         {
             free(buff);
         }


### PR DESCRIPTION
At line 57 in core/debug.c you typed ```buf``` instead ```buff```. Which leads to compilation error.

gcc error report:
```bash
$ make
[...]
gcc -o core/debug.o -c core/debug.c -g -Wall -lpthread
core/debug.c: In function ‘DisplayDebug’:
core/debug.c:57:13: error: ‘buf’ undeclared (first use in this function); did you mean ‘buff’?
         if (buf)
             ^~~
             buff
core/debug.c:57:13: note: each undeclared identifier is reported only once for each function it appears in
make: *** [Makefile:20: core/debug.o] Error 1
```

Thanks,
Clément Boin

